### PR TITLE
* Rename CPU to CPUS in LaunchReq parameters

### DIFF
--- a/multipass/info.go
+++ b/multipass/info.go
@@ -10,7 +10,7 @@ type InfoRequest struct {
 
 func Info(req *InfoRequest) (*Instance, error) {
 
-	cmdFormat := "multipass info "+ req.Name
+	cmdFormat := "multipass info " + req.Name
 
 	cmdExec := exec.Command("sh", "-c", cmdFormat)
 

--- a/multipass/launch.go
+++ b/multipass/launch.go
@@ -1,14 +1,14 @@
 package multipass
 
 import (
-	"fmt"
+	"errors"
 	"os/exec"
 	"strings"
 )
 
 type LaunchReq struct {
 	Image         string
-	CPU           int
+	CPUS          string
 	Disk          string
 	Name          string
 	Memory        string
@@ -16,40 +16,36 @@ type LaunchReq struct {
 }
 
 func Launch(launchReq *LaunchReq) (*Instance, error) {
-
-	var args = ""
+	var args = []string{"launch"}
 
 	if launchReq.Image != "" {
-		args = args + fmt.Sprintf(" %v", launchReq.Image)
+		args = append(args, launchReq.Image)
 	}
 
-	if launchReq.CPU != 0 {
-		args = args + fmt.Sprintf(" --cpus %v", launchReq.CPU)
+	if launchReq.CPUS != "" {
+		args = append(args, "--cpus", launchReq.CPUS)
 	}
 
 	if launchReq.Name != "" {
-		args = args + fmt.Sprintf(" --name %v", launchReq.Name)
+		args = append(args, "--name", launchReq.Name)
 	}
 
 	if launchReq.Disk != "" {
-		args = args + fmt.Sprintf(" --disk %v", launchReq.Disk)
+		args = append(args, "--disk", launchReq.Disk)
 	}
 
 	if launchReq.Memory != "" {
-		args = args + fmt.Sprintf(" --mem %v", launchReq.Memory)
+		args = append(args, "--mem", launchReq.Memory)
 	}
 
 	if launchReq.CloudInitFile != "" {
-		args = args + fmt.Sprintf(" --cloud-init %v", launchReq.CloudInitFile)
+		args = append(args, "--cloud-init", launchReq.CloudInitFile)
 	}
 
-	cmd := fmt.Sprintf("multipass launch " + args)
-
-	cmdExec := exec.Command("sh", "-c", cmd)
-	out, err := cmdExec.CombinedOutput()
+	result := exec.Command("multipass", args...)
+	out, err := result.CombinedOutput()
 	if err != nil {
-		fmt.Println(string(out))
-		return nil, err
+		return nil, errors.New(string(out) + " " + err.Error())
 	}
 
 	var b []byte

--- a/multipass/multipass_test.go
+++ b/multipass/multipass_test.go
@@ -7,31 +7,31 @@ import (
 
 func TestCreateInfoAndDelete(t *testing.T) {
 	instance, err := Launch(&LaunchReq{
-		CPU:           2,
+		CPUS: "2",
 		Name: "test2",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Log("created instance "+instance.IP)
+	t.Log("created instance " + instance.IP)
 
-	instanceInfo, err := Info(&InfoRequest{Name:instance.Name})
+	instanceInfo, err := Info(&InfoRequest{Name: instance.Name})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Log("instance information "+instanceInfo.Name)
-	t.Log("instance information "+instanceInfo.IP)
+	t.Log("instance information " + instanceInfo.Name)
+	t.Log("instance information " + instanceInfo.IP)
 
-	err = Exec(&ExecRequest{Name:instanceInfo.Name, Command:"ls"})
+	err = Exec(&ExecRequest{Name: instanceInfo.Name, Command: "ls"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Log("now deleting "+instance.Name)
+	t.Log("now deleting " + instance.Name)
 
-	if err := Delete(&DeleteRequest{Name:instance.Name}); err != nil {
+	if err := Delete(&DeleteRequest{Name: instance.Name}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -48,7 +48,6 @@ Load:           0.06 0.07 0.02
 Disk usage:     988.2M out of 4.7G
 Memory usage:   83.6M out of 985.6M`)
 
-
-fmt.Printf(instance.IP)
+	fmt.Printf(instance.IP)
 
 }


### PR DESCRIPTION
* Use string as parameter to CPUS instead of int
* Convert exec.Command to exec without shell
* Add stderr text to error message for Launch