### PR TITLE
Fix --mem argument in launchV2

### DIFF
--- a/multipass/launch.go
+++ b/multipass/launch.go
@@ -60,7 +60,7 @@ func LaunchV2(launchReqV2 *LaunchReqV2) (*Instance, error) {
 	}
 
 	if launchReqV2.Memory != "" {
-		args = append(args, "--mem", launchReqV2.Memory)
+		args = append(args, "--memory", launchReqV2.Memory)
 	}
 
 	if launchReqV2.CloudInitFile != "" {


### PR DESCRIPTION
Last multipass version changed memory argument from --mem to --memory