### PR TITLE
fixes find test by ignoring image version

### DIFF
--- a/multipass/find_test.go
+++ b/multipass/find_test.go
@@ -21,7 +21,15 @@ func TestFindByAlias(t *testing.T) {
 		Aliases: []string{},
 	}
 
-	if reflect.DeepEqual(*result, expected) {
+	imagesEqual := true
+
+	if result.Os != expected.Os {
+		imagesEqual = false
+	}
+	if result.Release != expected.Release {
+		imagesEqual = false
+	}
+	if reflect.DeepEqual(result.Aliases, expected.Aliases) && imagesEqual {
 		t.Logf("Success !")
 	} else {
 		fmt.Println("Expected:")


### PR DESCRIPTION
`TestFindByAlias` was failing due to newer versions being published. I updated the test to ignore that property. 