### PR TITLE
Add Network and Bridged fields to LaunchReqV2 and include them in Lau…

### DIFF
--- a/multipass/launch.go
+++ b/multipass/launch.go
@@ -22,6 +22,8 @@ type LaunchReqV2 struct {
 	Name          string
 	Memory        string
 	CloudInitFile string
+	Network       []string
+	Bridged       bool
 }
 
 func Launch(launchReq *LaunchReq) (*Instance, error) {
@@ -66,6 +68,16 @@ func LaunchV2(launchReqV2 *LaunchReqV2) (*Instance, error) {
 
 	if launchReqV2.CloudInitFile != "" {
 		args = append(args, "--cloud-init", launchReqV2.CloudInitFile)
+	}
+
+	// Add network specifications
+	for _, network := range launchReqV2.Network {
+		args = append(args, "--network", network)
+	}
+
+	// Add bridged network if requested
+	if launchReqV2.Bridged {
+		args = append(args, "--bridged")
 	}
 
 	result := exec.Command("multipass", args...)


### PR DESCRIPTION
This pull request updates the `LaunchReqV2` struct and the `LaunchV2` function in `multipass/launch.go` to support more flexible network configuration when launching instances. The main changes add support for specifying multiple networks and enabling bridged networking.

**Network configuration enhancements:**

* Added `Network` (slice of strings) and `Bridged` (boolean) fields to the `LaunchReqV2` struct to allow users to specify multiple networks and request bridged networking.
* Updated the `LaunchV2` function to append `--network` arguments for each specified network and to add the `--bridged` flag if requested, enabling advanced network setup during instance launch.